### PR TITLE
Return forkJoin after all params evaluated

### DIFF
--- a/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view-permalink.service.ts
+++ b/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view-permalink.service.ts
@@ -34,12 +34,11 @@ export class DiagramViewPermalinkService extends PermalinkService<void> {
   }
 
   private handleParams(params: Params): Observable<boolean> {
+    const valid: Observable<boolean>[] = [];
     if (params[PARAM_IDS]) {
       this.timeseriesSrvc.removeAllDatasets(true);
       const ids = (params[PARAM_IDS] as string).split(ID_SEPERATOR);
-      return forkJoin(
-        ids.map(id => from(this.timeseriesSrvc.addDataset(id)))
-      ).pipe(map(res => true));
+      valid.push(...ids.map((id) => from(this.timeseriesSrvc.addDataset(id))));
     }
     if (params[PARAM_TIME]) {
       const time = (params[PARAM_TIME] as string).split(TIME_SEPERATOR);
@@ -53,7 +52,7 @@ export class DiagramViewPermalinkService extends PermalinkService<void> {
       const timespan = this.definedTimeintervalSrvc.getInterval(definedTime);
       if (timespan) { this.timeseriesSrvc.timespan = timespan; }
     }
-    return of(true);
+    return forkJoin(valid).pipe(map((res) => true));
   }
 
   protected generatePermalink(): string {


### PR DESCRIPTION
While validating permalinks, the datasets are set but all other parameters are not recognized anymore. There's an immediate return statement before other parameters are handled:

https://github.com/52North/helgoland-toolbox/blob/50f8504f608c8ee544d89d1e2718be961893da51/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view-permalink.service.ts#L40-L42

The fix just  moves the `forkJoin` to the end of the method bulk handling all observables collected during the call (which are actually only the datasets requests). 

Closes #166 (hopefully)

Not sure, if I would had to take care of any other side effects. Please make sure, this fix does not have any regressions.