### PR TITLE
Opens map selection by default (regression)

### DIFF
--- a/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view-permalink.service.ts
+++ b/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view-permalink.service.ts
@@ -52,7 +52,7 @@ export class DiagramViewPermalinkService extends PermalinkService<void> {
       const timespan = this.definedTimeintervalSrvc.getInterval(definedTime);
       if (timespan) { this.timeseriesSrvc.timespan = timespan; }
     }
-    return forkJoin(valid).pipe(map((res) => true));
+    return of(valid.length == 0) || forkJoin(valid).pipe(map(() => true));
   }
 
   protected generatePermalink(): string {

--- a/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view-permalink.service.ts
+++ b/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view-permalink.service.ts
@@ -52,7 +52,11 @@ export class DiagramViewPermalinkService extends PermalinkService<void> {
       const timespan = this.definedTimeintervalSrvc.getInterval(definedTime);
       if (timespan) { this.timeseriesSrvc.timespan = timespan; }
     }
-    return of(valid.length == 0) || forkJoin(valid).pipe(map(() => true));
+    if (valid.length) {
+      return forkJoin(valid).pipe(map(() => true));
+    } else {
+      return of(true);
+    };
   }
 
   protected generatePermalink(): string {

--- a/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view.component.ts
+++ b/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view.component.ts
@@ -126,7 +126,7 @@ export class DiagramViewComponent implements OnInit {
   // }
 
   ngOnInit(): void {
-    this.permalinkSrvc.validatePeramlink().subscribe(res => {
+    this.permalinkSrvc.validatePeramlink().subscribe(() => {
       if (!this.timeseries.hasDatasets()) {
         this.openMapSelection();
       }


### PR DESCRIPTION
(I had to create a new PR after cleaning up the branch)

In case of no selected datasets the map-selection view shall be opened by default. Seems that #167 introduced a regression (at least did not test and fix this behavior). However, the fix now ensures to return a valid `Observable` after validating a permalink even when parameters are available, so that `map-selection` will open even when no datasets are selected:

https://github.com/52North/helgoland-toolbox/blob/69c68eecc28216d960afdadd1460d50fe163faf3/projects/helgoland-timeseries/src/app/views/diagram-view/diagram-view.component.ts#L129-L133

Closes #168