### PR TITLE
docs: update Node.js and NPM version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,13 @@ Research covered experimenting on how to achieve the integration of access-contr
 ## Quick Start
 
 ### Dependencies
+Make sure you have Node.js version ≥ 18 (LTS recommended) and NPM ≥ 9.
 
-#### Node/NPM
+Ensure that:
+- Node.js ≥ 18
+- NPM ≥ 9
+
+Older versions may not be compatible with modern Angular builds.
 
 Install latest Node and NPM following the [instructions](https://nodejs.org/en/download/). Make sure you have Node version ≥ 10 and NPM ≥ 6. `brew install node` for Mac.
 
@@ -154,6 +159,7 @@ The software is in operational use by the following organizations or within the 
 
 - add `allowSyntheticDefaultImports: true` to your tsconfig.json to avoid error messages like `... has no default export`
 - don't forget to add styles of nested dependencies
+
 
 
 ## Funding organizations/projects

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Ensure that:
 - Node.js ≥ 18
 - NPM ≥ 9
 
-Older versions may not be compatible with modern Angular builds.
+This project contains Angular-based modules, components, and services to build a sensor observation service-based client.
 
 Install latest Node and NPM following the [instructions](https://nodejs.org/en/download/). Make sure you have Node version ≥ 10 and NPM ≥ 6. `brew install node` for Mac.
 


### PR DESCRIPTION
This PR updates the Node.js and NPM version requirements in the README to reflect modern LTS versions.

The previous version requirement (Node ≥ 10) is outdated and may cause confusion for new contributors.